### PR TITLE
[ci] sync template files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ web_modules/
 .cache
 .parcel-cache
 
+# Astro 
+.astro
+
 # Next.js build output
 .next
 out


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- add .astro to .gitignore - ([26c923f](https://github.com/trueberryless-org/template-files/commit/26c923fceb0e937a00a8854dfd18b76c665270e3))