### PR TITLE
[ci] sync template files

### DIFF
--- a/manifest-lunaria/deployment.yaml
+++ b/manifest-lunaria/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: i18n-mutanuq
-  namespace: i18n-mutanuq
+  name: <%= repositoryName %>
+  namespace: <%= repositoryName %>
   labels:
-    app: i18n-mutanuq
+    app: <%= repositoryName %>
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: i18n-mutanuq
+      app: <%= repositoryName %>
   template:
     metadata:
       labels:
-        app: i18n-mutanuq
+        app: <%= repositoryName %>
     spec:
       containers:
-        - name: i18n-mutanuq
-          image: "trueberryless/i18n-mutanuq"
+        - name: <%= repositoryName %>
+          image: "trueberryless/<%= repositoryName %>"
           imagePullPolicy: Always

--- a/manifest/deployment.yaml
+++ b/manifest/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mutanuq
-  namespace: mutanuq
+  name: <%= repositoryName %>
+  namespace: <%= repositoryName %>
   labels:
-    app: mutanuq
+    app: <%= repositoryName %>
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: mutanuq
+      app: <%= repositoryName %>
   template:
     metadata:
       labels:
-        app: mutanuq
+        app: <%= repositoryName %>
     spec:
       containers:
-        - name: mutanuq
-          image: "trueberryless/mutanuq"
+        - name: <%= repositoryName %>
+          image: "trueberryless/<%= repositoryName %>"
           imagePullPolicy: Always


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- add special handling for deployment file - ([60e9260](https://github.com/trueberryless-org/template-files/commit/60e9260319a3aedf272e689bc7fd20e83748bdf6))