### PR TITLE
[ci] sync template files

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,43 +1,37 @@
-name: Format
-
+name: autofix.ci
 on:
+  pull_request:
   push:
     branches: [main]
+permissions:
+  contents: read
 
 jobs:
-  format:
+  autofix:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: |
-            - recursive: false
-              args: [--frozen-lockfile]
-            - args: [--global, prettier, sort-package-json]
-      - uses: actions/setup-node@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
-      - name: Sort package.json
-        run: find . -name "package.json" -not -path "*/node_modules/*" -exec sort-package-json {} \;
-      - name: Format with Prettier
-        run: pnpm prettier --write .
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.PUBLIC_GITHUB_TOKEN }}
-          commit-message: "[ci] format"
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          signoff: false
-          branch: ci-format
-          delete-branch: true
-          title: "[ci] format"
-          body: "This PR was automatically created to sort package.json files in the repository using sort-package-json and to format the repository using prettier."
-          labels: 🤖 bot
-          assignees: trueberryless
-          draft: false
+
+      - name: Install Dependencies
+        run: pnpm i
+
+      - name: Run prettier
+        run: npx prettier --write .
+
+      # Optimize all PNGs with https://pngquant.org/
+      - run: sudo apt-get update && sudo apt-get install -y pngquant
+      - name: Run pngquant
+        run: |
+          shopt -s globstar
+          find . -name '*.png' -exec pngquant --ext .png --force 256 {} \;
+
+      - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- Merge pull request trueberryless-org/template-files#57 from trueberryless-org/changeset-release/main - ([fa25599](https://github.com/trueberryless-org/template-files/commit/fa25599762470c4e265b7417b0618d3b14305dae))
- fix autofix action - ([4f46cc1](https://github.com/trueberryless-org/template-files/commit/4f46cc14d891d4381de1b00fff1342abef6872a9))
- try fixing png optimizer - ([8ca6e4f](https://github.com/trueberryless-org/template-files/commit/8ca6e4f00899e68dff825ad9e3e8bcb9dc28ecaa))